### PR TITLE
Fix: npm WARN htmlparser@1.7.3 package.json: bugs['web'] should probably be bugs['url']

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	}
 	, "bugs": {
 		  "mail": "chris@winberry.net"
-		, "web": "http://github.com/tautologistics/node-htmlparser/issues"
+		, "url": "http://github.com/tautologistics/node-htmlparser/issues"
 	}
 	, "os": [ "linux", "darwin", "freebsd", "win32" ]
 	, "directories": { "lib": "./lib/" }


### PR DESCRIPTION
Fix: npm WARN htmlparser@1.7.3 package.json: bugs['web'] should probably be bugs['url']
