### PR TITLE
Change sys to util

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ View runtests.html in any browser
 	});
 	var parser = new htmlparser.Parser(handler);
 	parser.parseComplete(rawHtml);
-	sys.puts(sys.inspect(handler.dom, false, null));
+	util.puts(util.inspect(handler.dom, false, null));
 
 ##Usage In Browser
 	var handler = new Tautologistics.NodeHtmlParser.DefaultHandler(function (error, dom) {

--- a/profile.js
+++ b/profile.js
@@ -1,6 +1,6 @@
 //node --prof --prof_auto profile.js
 //deps/v8/tools/mac-tick-processor v8.log
-var sys = require("sys");
+var util = require("util");
 var fs = require("fs");
 var http = require("http");
 var htmlparser = require("./lib/htmlparser");
@@ -39,7 +39,7 @@ http.createClient(testPort, testHost)
 				var timeNodeHtmlParser = !testNHP ? 0 : timeExecutions(testIterations, function () {
 					var handler = new htmlparser.DefaultHandler(function(err, dom) {
 						if (err)
-							sys.debug("Error: " + err);
+							util.debug("Error: " + err);
 					});
 					var parser = new htmlparser.Parser(handler, { includeLocation: true });
 					parser.parseComplete(html);
@@ -50,14 +50,14 @@ http.createClient(testPort, testHost)
 				})
 
 				if (testNHP)
-					sys.debug("NodeHtmlParser: "  + timeNodeHtmlParser);
+					util.debug("NodeHtmlParser: "  + timeNodeHtmlParser);
 				if (testLXJS)
-					sys.debug("LibXmlJs: "  + timeLibXmlJs);
+					util.debug("LibXmlJs: "  + timeLibXmlJs);
 				if (testNHP && testLXJS)
-					sys.debug("Difference: " + ((timeNodeHtmlParser - timeLibXmlJs) / timeLibXmlJs) * 100);
+					util.debug("Difference: " + ((timeNodeHtmlParser - timeLibXmlJs) / timeLibXmlJs) * 100);
 			});
 		}
 		else
-			sys.debug("Error: got response status " + response.statusCode);
+			util.debug("Error: got response status " + response.statusCode);
 	})
 	.end();

--- a/runtests.js
+++ b/runtests.js
@@ -19,7 +19,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 ***********************************************/
 
-var sys = require("sys");
+var util = require("util");
 var fs = require("fs");
 var htmlparser = require("./lib/htmlparser");
 
@@ -37,7 +37,7 @@ for (var i in testFiles) {
 	var test = require(testFolder + "/" + moduleName);
 	var handlerCallback = function handlerCallback (error) {
 		if (error)
-			sys.puts("Handler error: " + error);
+			util.puts("Handler error: " + error);
 	}
 	var handler = (test.type == "rss") ?
 		new htmlparser.RssHandler(handlerCallback, test.options.handler)
@@ -56,20 +56,20 @@ for (var i in testFiles) {
 	parser.done();
 	var resultChunk = handler.dom;
 	var testResult =
-		sys.inspect(resultComplete, false, null) === sys.inspect(test.expected, false, null)
+		util.inspect(resultComplete, false, null) === util.inspect(test.expected, false, null)
 		&&
-		sys.inspect(resultChunk, false, null) === sys.inspect(test.expected, false, null)
+		util.inspect(resultChunk, false, null) === util.inspect(test.expected, false, null)
 		;
-	sys.puts("[" + test.name + "\]: " + (testResult ? "passed" : "FAILED"));
+	util.puts("[" + test.name + "\]: " + (testResult ? "passed" : "FAILED"));
 	if (!testResult) {
 		failedCount++;
-		sys.puts("== Complete ==");
-		sys.puts(sys.inspect(resultComplete, false, null));
-		sys.puts("== Chunked ==");
-		sys.puts(sys.inspect(resultChunk, false, null));
-		sys.puts("== Expected ==");
-		sys.puts(sys.inspect(test.expected, false, null));
+		util.puts("== Complete ==");
+		util.puts(util.inspect(resultComplete, false, null));
+		util.puts("== Chunked ==");
+		util.puts(util.inspect(resultChunk, false, null));
+		util.puts("== Expected ==");
+		util.puts(util.inspect(test.expected, false, null));
 	}
 }
-sys.puts("Total tests: " + testCount);
-sys.puts("Failed tests: " + failedCount);
+util.puts("Total tests: " + testCount);
+util.puts("Failed tests: " + failedCount);

--- a/runtests.min.js
+++ b/runtests.min.js
@@ -19,7 +19,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 ***********************************************/
 
-var sys = require("sys");
+var util = require("util");
 var fs = require("fs");
 var htmlparser = require("./lib/htmlparser.min");
 
@@ -37,7 +37,7 @@ for (var i in testFiles) {
 	var test = require(testFolder + "/" + moduleName);
 	var handlerCallback = function handlerCallback (error) {
 		if (error)
-			sys.puts("Handler error: " + error);
+			util.puts("Handler error: " + error);
 	}
 	var handler = (test.type == "rss") ?
 		new htmlparser.RssHandler(handlerCallback, test.options.handler)
@@ -56,20 +56,20 @@ for (var i in testFiles) {
 	parser.done();
 	var resultChunk = handler.dom;
 	var testResult =
-		sys.inspect(resultComplete, false, null) === sys.inspect(test.expected, false, null)
+		util.inspect(resultComplete, false, null) === util.inspect(test.expected, false, null)
 		&&
-		sys.inspect(resultChunk, false, null) === sys.inspect(test.expected, false, null)
+		util.inspect(resultChunk, false, null) === util.inspect(test.expected, false, null)
 		;
-	sys.puts("[" + test.name + "\]: " + (testResult ? "passed" : "FAILED"));
+	util.puts("[" + test.name + "\]: " + (testResult ? "passed" : "FAILED"));
 	if (!testResult) {
 		failedCount++;
-		sys.puts("== Complete ==");
-		sys.puts(sys.inspect(resultComplete, false, null));
-		sys.puts("== Chunked ==");
-		sys.puts(sys.inspect(resultChunk, false, null));
-		sys.puts("== Expected ==");
-		sys.puts(sys.inspect(test.expected, false, null));
+		util.puts("== Complete ==");
+		util.puts(util.inspect(resultComplete, false, null));
+		util.puts("== Chunked ==");
+		util.puts(util.inspect(resultChunk, false, null));
+		util.puts("== Expected ==");
+		util.puts(util.inspect(test.expected, false, null));
 	}
 }
-sys.puts("Total tests: " + testCount);
-sys.puts("Failed tests: " + failedCount);
+util.puts("Total tests: " + testCount);
+util.puts("Failed tests: " + failedCount);

--- a/snippet.js
+++ b/snippet.js
@@ -1,15 +1,15 @@
 //node --prof --prof_auto profile.js
 //deps/v8/tools/mac-tick-processor v8.log
-var sys = require("sys");
+var util = require("util");
 var htmlparser = require("./htmlparser");
 
 var html = "<link>text</link>";
 
 var handler = new htmlparser.DefaultHandler(function(err, dom) {
 	if (err)
-		sys.debug("Error: " + err);
+		util.debug("Error: " + err);
 	else
-		sys.debug(sys.inspect(dom, false, null));
+		util.debug(util.inspect(dom, false, null));
 }, { enforceEmptyTags: true });
 var parser = new htmlparser.Parser(handler);
 parser.parseComplete(html);

--- a/utils_example.js
+++ b/utils_example.js
@@ -1,34 +1,34 @@
 //node --prof --prof_auto profile.js
 //deps/v8/tools/mac-tick-processor v8.log
-var sys = require("sys");
+var util = require("util");
 var htmlparser = require("./lib/htmlparser");
 
 var html = "<a>text a</a><b id='x'>text b</b><c class='y'>text c</c><d id='z' class='w'><e>text e</e></d><g class='g h i'>hhh</g><yy>hellow</yy><yy id='secondyy'>world</yy>";
 
 var handler = new htmlparser.DefaultHandler(function(err, dom) {
 	if (err) {
-		sys.debug("Error: " + err);
+		util.debug("Error: " + err);
 	}
 	else {
-		sys.debug(sys.inspect(dom, false, null));
+		util.debug(util.inspect(dom, false, null));
 		var id = htmlparser.DomUtils.getElementById("x", dom);
-		sys.debug("id: " + sys.inspect(id, false, null));
+		util.debug("id: " + util.inspect(id, false, null));
 		var class = htmlparser.DomUtils.getElements({ class: "y" }, dom);
-		sys.debug("class: " + sys.inspect(class, false, null));
+		util.debug("class: " + util.inspect(class, false, null));
 		var multiclass = htmlparser.DomUtils.getElements({ class: function (value) { return(value && value.indexOf("h") > -1); } }, dom);
-		sys.debug("multiclass: " + sys.inspect(multiclass, false, null));
+		util.debug("multiclass: " + util.inspect(multiclass, false, null));
 		var name = htmlparser.DomUtils.getElementsByTagName("a", dom);
-		sys.debug("name: " + sys.inspect(name, false, null));
+		util.debug("name: " + util.inspect(name, false, null));
 		var text = htmlparser.DomUtils.getElementsByTagType("text", dom);
-		sys.debug("text: " + sys.inspect(text, false, null));
+		util.debug("text: " + util.inspect(text, false, null));
 		var nested = htmlparser.DomUtils.getElements({ tag_name: "d", id: "z", class: "w" }, dom);
 		nested = htmlparser.DomUtils.getElementsByTagName("e", nested);
 		nested = htmlparser.DomUtils.getElementsByTagType("text", nested);
-		sys.debug("nested: " + sys.inspect(nested, false, null));
+		util.debug("nested: " + util.inspect(nested, false, null));
 		var double = htmlparser.DomUtils.getElementsByTagName("yy", dom);
-		sys.debug("double: " + sys.inspect(double, false, null));
+		util.debug("double: " + util.inspect(double, false, null));
 		var single = htmlparser.DomUtils.getElements( { tag_name: "yy", id: "secondyy" }, dom);
-		sys.debug("single: " + sys.inspect(single, false, null));
+		util.debug("single: " + util.inspect(single, false, null));
 	}
 }, { verbose: false });
 var parser = new htmlparser.Parser(handler);


### PR DESCRIPTION
The sys module is deprecated and spews a warning on stdout on node 0.6. Changed it's name to util, which is the new name. Also works on 0.4 (at least 0.4.7). The sys module has been deprecated for a year.
