### PR TITLE
Wrong results when parsing mixed-case tags

### DIFF
--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -684,8 +684,8 @@ function DefaultHandler (callback, options) {
 					var baseName = element.name.substring(1);
 					if (!this.isEmptyTag(element)) {
 						var pos = this._tagStack.length - 1;
-						while (pos > -1 && this._tagStack[pos--].name != baseName) { }
-						if (pos > -1 || this._tagStack[0].name == baseName)
+						while (pos > -1 && this._tagStack[pos--].name.toLowerCase() != baseName.toLowerCase()) { }
+						if (pos > -1 || this._tagStack[0].name.toLowerCase() == baseName.toLowerCase())
 							while (pos < this._tagStack.length - 1)
 								this._tagStack.pop();
 					}


### PR DESCRIPTION
Prior to this patch, I got different results for these lines:

`<html><head></head><body>foo</body></html>`
`<html><head></HEAD><body>foo</BODY></HTML>`

Now you get the same thing for either of them:

```
[ { raw: 'html',
    data: 'html',
    type: 'tag',
    name: 'html',
    children: 
     [ { raw: 'head', data: 'head', type: 'tag', name: 'head' },
       { raw: 'body',
         data: 'body',
         type: 'tag',
         name: 'body',
         children: [ { raw: 'foo', data: 'foo', type: 'text' } ] } ] } ]
```

All of the tests still pass.
