### PR TITLE
Do a case insensitive comparison when checking whether we're inside <script> or <style>

### DIFF
--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -227,7 +227,7 @@ function Parser (handler, options) {
 				, type: this._parseState
 			};
 	
-			var elementName = this.parseTagName(element.data);
+			var elementName = this.parseTagName(element.data).toLowerCase();
 	
 			//This section inspects the current tag stack and modifies the current
 			//element if we're actually parsing a special area (script/comment/style tag)


### PR DESCRIPTION
Previously this test case failed:

```
var rawHtml = '<SCRIPT>document.write("</style>");</SCRIPT></body></html>',
    htmlparser = require('./lib/htmlparser'),
    handler = new htmlparser.DefaultHandler(),
    parser = new htmlparser.Parser(handler);
parser.parseComplete(rawHtml);
console.warn(require('util').inspect(handler.dom, false, null));
```

Output:

```
[ { raw: 'SCRIPT',
    data: 'SCRIPT',
    type: 'tag',
    name: 'SCRIPT',
    children: 
     [ { raw: 'document.write("',
         data: 'document.write("',
         type: 'text' },
       { raw: '");', data: '");', type: 'text' } ] } ]
```

This patch fixes it so the output is:

```
[ { raw: 'SCRIPT',
    data: 'SCRIPT',
    type: 'script',
    name: 'script',
    children: 
     [ { raw: 'document.write("</style>");',
         data: 'document.write("</style>");',
         type: 'text' } ] } ]
```
