### PR TITLE
Include 'sunos' to enable installation on SmartOS, Illumos, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		  "mail": "chris@winberry.net"
 		, "url": "http://github.com/tautologistics/node-htmlparser/issues"
 	}
-	, "os": [ "linux", "darwin", "freebsd", "win32", "openbsd" ]
+	, "os": [ "linux", "darwin", "freebsd", "win32", "openbsd", "sunos" ]
 	, "directories": { "lib": "./lib/" }
 	, "main": "./lib/htmlparser"
 	, "engines": { "node": ">=0.1.33" }


### PR DESCRIPTION
Or, since it's pure JS, removing the 'os' line seems like a good option.

In any case, all tests pass on SmartOS, and no problems in use.

```
# node runtests.js 
The "sys" module is now called "util". It should have a similar interface.
[RSS (2.0)]: passed
[Atom (1.0)]: passed
[Unquoted attributes]: passed
[Enforce empty tags]: passed
[XML Namespace]: passed
[Extra spaces in tag]: passed
[Ignore empty tags]: passed
[Single Tag 1]: passed
[Single Tag 2]: passed
[Only text]: passed
[Unescaped chars in script]: passed
[Comment within text within script]: passed
[Script source in comment]: passed
[Comment within text]: passed
[Postion data]: passed
[Singular attribute]: passed
[Text outside tags]: passed
[Options 'ignoreWhitespace' set to 'true']: passed
[Option 'verbose' set to 'false']: passed
[Basic test]: passed
[Unescaped chars in style]: passed
[Special char in comment]: passed
Total tests: 22
Failed tests: 0
```
