### PR TITLE
Omittable closing tags

### DIFF
--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -100,7 +100,7 @@ function Parser (handler, options) {
 		if (this._done)
 			return;
 		this._done = true;
-	
+
 		//Push any unparsed text into a final element in the element list
 		if (this._buffer.length) {
 			var rawData = this._buffer;
@@ -115,7 +115,7 @@ function Parser (handler, options) {
 			this.parseAttribs(element);
 			this._elements.push(element);
 		}
-	
+
 		this.writeHandler();
 		this._handler.done();
 	}
@@ -139,7 +139,7 @@ function Parser (handler, options) {
 		this._tagStack = [];
 		this._handler.reset();
 	}
-	
+
 	//**Private**//
 	//Properties//
 	Parser.prototype._options = null; //Parser options for how to behave
@@ -162,33 +162,33 @@ function Parser (handler, options) {
 	Parser.prototype.parseTagAttribs = function Parser$parseTagAttribs (elements) {
 		var idxEnd = elements.length;
 		var idx = 0;
-	
+
 		while (idx < idxEnd) {
 			var element = elements[idx++];
 			if (element.type == ElementType.Tag || element.type == ElementType.Script || element.type == ElementType.style)
 				this.parseAttribs(element);
 		}
-	
+
 		return(elements);
 	}
 
-	//Takes an element and adds an "attribs" property for any element attributes found 
+	//Takes an element and adds an "attribs" property for any element attributes found
 	Parser.prototype.parseAttribs = function Parser$parseAttribs (element) {
 		//Only parse attributes for tags
 		if (element.type != ElementType.Script && element.type != ElementType.Style && element.type != ElementType.Tag)
 			return;
-	
+
 		var tagName = element.data.split(Parser._reWhitespace, 1)[0];
 		var attribRaw = element.data.substring(tagName.length);
 		if (attribRaw.length < 1)
 			return;
-	
+
 		var match;
 		Parser._reAttrib.lastIndex = 0;
 		while (match = Parser._reAttrib.exec(attribRaw)) {
 			if (element.attribs == undefined)
 				element.attribs = {};
-	
+
 			if (typeof match[1] == "string" && match[1].length) {
 				element.attribs[match[1]] = match[2];
 			} else if (typeof match[3] == "string" && match[3].length) {
@@ -219,16 +219,16 @@ function Parser (handler, options) {
 			this._next = Parser._reTags.lastIndex - 1;
 			var tagSep = this._buffer.charAt(this._next); //The currently found tag marker
 			var rawData = this._buffer.substring(this._current, this._next); //The next chunk of data to parse
-	
+
 			//A new element to eventually be appended to the element list
 			var element = {
 				  raw: rawData
 				, data: (this._parseState == ElementType.Text) ? rawData : rawData.replace(Parser._reTrim, "")
 				, type: this._parseState
 			};
-	
+
 			var elementName = this.parseTagName(element.data);
-	
+
 			//This section inspects the current tag stack and modifies the current
 			//element if we're actually parsing a special area (script/comment/style tag)
 			if (this._tagStack.length) { //We're parsing inside a script/comment/style tag
@@ -301,12 +301,12 @@ function Parser (handler, options) {
 					}
 				}
 			}
-	
+
 			//Processing of non-special tags
 			if (element.type == ElementType.Tag) {
 				element.name = elementName;
 				var elementNameCI = elementName.toLowerCase();
-				
+
 				if (element.raw.indexOf("!--") == 0) { //This tag is really comment
 					element.type = ElementType.Comment;
 					delete element["name"];
@@ -342,7 +342,7 @@ function Parser (handler, options) {
 				if (element.name && element.name.charAt(0) == "/")
 					element.data = element.name;
 			}
-	
+
 			//Add all tags and non-empty text elements to the element list
 			if (element.raw != "" || element.type != ElementType.Text) {
 				if (this._options.includeLocation && !element.location) {
@@ -380,7 +380,7 @@ function Parser (handler, options) {
 		}
 		this._buffer = (this._current <= bufferEnd) ? this._buffer.substring(this._current) : "";
 		this._current = 0;
-	
+
 		this.writeHandler();
 	}
 
@@ -389,7 +389,7 @@ function Parser (handler, options) {
 			l = this._location,
 			end = this._current - (startTag ? 1 : 0),
 			chunk = startTag && l.charOffset == 0 && this._current == 0;
-		
+
 		for (; l.charOffset < end; l.charOffset++) {
 			c = this._buffer.charAt(l.charOffset);
 			if (c == '\n') {
@@ -611,16 +611,16 @@ function DefaultHandler (callback, options) {
 	}
 	DefaultHandler.prototype.writeTag = function DefaultHandler$writeTag (element) {
 		this.handleElement(element);
-	} 
+	}
 	DefaultHandler.prototype.writeText = function DefaultHandler$writeText (element) {
 		if (this._options.ignoreWhitespace)
 			if (DefaultHandler.reWhitespace.test(element.data))
 				return;
 		this.handleElement(element);
-	} 
+	}
 	DefaultHandler.prototype.writeComment = function DefaultHandler$writeComment (element) {
 		this.handleElement(element);
-	} 
+	}
 	DefaultHandler.prototype.writeDirective = function DefaultHandler$writeDirective (element) {
 		this.handleElement(element);
 	}
@@ -643,7 +643,7 @@ function DefaultHandler (callback, options) {
 					return;
 			this._callback(error, this.dom);
 	}
-	
+
 	DefaultHandler.prototype.isEmptyTag = function(element) {
 		var name = element.name.toLowerCase();
 		if (name.charAt(0) == '/') {
@@ -651,7 +651,7 @@ function DefaultHandler (callback, options) {
 		}
 		return this._options.enforceEmptyTags && !!DefaultHandler._emptyTags[name];
 	};
-	
+
 	DefaultHandler.prototype.handleElement = function DefaultHandler$handleElement (element) {
 		if (this._done)
 			this.handleCallback(new Error("Writing to the handler after done() called is not allowed without a reset()"));
@@ -712,7 +712,7 @@ function DefaultHandler (callback, options) {
 			if (!element) {
 				return false;
 			}
-	
+
 			for (var key in options) {
 				if (key == "tag_name") {
 					if (element.type != "tag" && element.type != "script" && element.type != "style") {
@@ -738,10 +738,10 @@ function DefaultHandler (callback, options) {
 					}
 				}
 			}
-		
+
 			return true;
 		}
-	
+
 		, getElements: function DomUtils$getElements (options, currentElement, recurse, limit) {
 			recurse = (recurse === undefined || recurse === null) || !!recurse;
 			limit = isNaN(parseInt(limit)) ? -1 : parseInt(limit);
@@ -749,7 +749,7 @@ function DefaultHandler (callback, options) {
 			if (!currentElement) {
 				return([]);
 			}
-	
+
 			var found = [];
 			var elementList;
 
@@ -761,7 +761,7 @@ function DefaultHandler (callback, options) {
 					options[key] = getTest(options[key]);
 				}
 			}
-	
+
 			if (DomUtils.testElement(options, currentElement)) {
 				found.push(currentElement);
 			}
@@ -777,26 +777,26 @@ function DefaultHandler (callback, options) {
 			} else {
 				return(found);
 			}
-	
+
 			for (var i = 0; i < elementList.length; i++) {
 				found = found.concat(DomUtils.getElements(options, elementList[i], recurse, limit));
 				if (limit >= 0 && found.length >= limit) {
 					break;
 				}
 			}
-	
+
 			return(found);
 		}
-		
+
 		, getElementById: function DomUtils$getElementById (id, currentElement, recurse) {
 			var result = DomUtils.getElements({ id: id }, currentElement, recurse, 1);
 			return(result.length ? result[0] : null);
 		}
-		
+
 		, getElementsByTagName: function DomUtils$getElementsByTagName (name, currentElement, recurse, limit) {
 			return(DomUtils.getElements({ tag_name: name }, currentElement, recurse, limit));
 		}
-		
+
 		, getElementsByTagType: function DomUtils$getElementsByTagType (type, currentElement, recurse, limit) {
 			return(DomUtils.getElements({ tag_type: type }, currentElement, recurse, limit));
 		}

--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -55,6 +55,33 @@ var ElementType = {
 	, Tag: "tag" //Any tag that isn't special
 }
 
+
+var blockTags = [
+  'address', 'article', 'aside', 'audio', 'blockquote', 'canvas', 'dd', 'div',
+  'dl', 'fieldset', 'figcaption', 'figure', 'figcaption', 'footer', 'form',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'noscript',
+  'ol', 'output', 'p', 'pre', 'section', 'table', 'tfoot', 'ul', 'video'
+];
+
+var closingOpeningTags = {
+  'body': [ 'body' ],
+  'colgroup': [ 'colgroup', 'tr' ],
+  'dd': [ 'dd', 'dt' ],
+  'dt': [ 'dd', 'dt' ],
+  'head': [ 'body' ],
+  'li': [ 'li' ],
+  'optgroup': [ 'optgroup' ],
+  'option': [ 'optgroup', 'option' ],
+  'p': blockTags,
+  'tbody': [ 'tbody' ],
+  'td': [ 'td', 'th' ],
+  'tfoot': [ 'tbody' ],
+  'th': [ 'td', 'th' ],
+  'thead': [ 'tfoot', 'tbody' ],
+  'tr': [ 'tfoot', 'tbody', 'tr' ]
+};
+
+
 function Parser (handler, options) {
 	this._options = options ? options : { };
 	if (this._options.includeLocation == undefined) {
@@ -137,6 +164,7 @@ function Parser (handler, options) {
 		this._parseState = ElementType.Text;
 		this._prevTagSep = '';
 		this._tagStack = [];
+		this._openWithOptionalClosingTags = [];
 		this._handler.reset();
 	}
 
@@ -349,7 +377,13 @@ function Parser (handler, options) {
 					element.location = this.getLocation(element.type == ElementType.Tag);
 				}
 				this.parseAttribs(element);
+				this.handleOpenTagsAgainst(element);
 				this._elements.push(element);
+
+				if (this.hasOptionalClosingTag(element)) {
+					this._openWithOptionalClosingTags.push(element);
+				}
+
 				//If tag self-terminates, add an explicit, separate closing tag
 				if (
 					element.type != ElementType.Text
@@ -382,6 +416,33 @@ function Parser (handler, options) {
 		this._current = 0;
 
 		this.writeHandler();
+	}
+
+	Parser.prototype.handleOpenTagsAgainst = function (element) {
+		var tag = element.name;
+		if (!tag) return;
+
+		var open = this._openWithOptionalClosingTags;
+		var i = open.length;
+
+		for (var i = open.length - 1; i >= 0; --i) {
+			var open_name = open[i].name;
+			var tags = closingOpeningTags[open_name];
+			if (tags && tags.indexOf(tag) !== -1) {
+				this._elements.push({
+					raw: "/" + open_name,
+					data: "/" + open_name,
+					name: "/" + open_name,
+					type: open[i].type
+				})
+				open.pop();
+				break;
+			}
+		}
+	}
+
+	Parser.prototype.hasOptionalClosingTag = function (element) {
+		return !!closingOpeningTags[element.name];
 	}
 
 	Parser.prototype.getLocation = function Parser$getLocation (startTag) {


### PR DESCRIPTION
Hi,

there are several situations in which you can omit closing tags of some elements.

``` html
<p>First paragraph.
<p>Second paragraph.
```

This is valid HTML5 code and should be parsed as

``` html
<p>First paragraph.</p>
<p>Second paragraph.</p>
```

The parser instead nests the second paragraph into the former one as

``` html
<p>First paragraph.
  <p>Second paragraph.</p>
</p>
```

I tweaked the 1.x version of the parser. It should now correctly add closing tags when they are intentionally omitted.

The rules are in the `closingOpeningTags` map. There are lists of tags that close each of the elements that have ommitable closing tags.

For the HTML code above, the actual result is

``` html
<p>First paragraph.
</p><p>Second paragraph.</p>
```

(which is totally correct).

I hope you can include this in the codebase. Cheers!

P.S. My editor also removed trailing white space from all the lines. Let me know if that's a problem for you.
