### PR TITLE
Fixed parsing of an HTML tag as the first thing inside a <script>.

### DIFF
--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -238,13 +238,17 @@ function Parser (handler, options) {
 					else { //Not a closing script tag
 						if (element.raw.indexOf("!--") != 0) { //Make sure we're not in a comment
 							//All data from here to script close is now a text element
-							element.type = ElementType.Text;
 							//If the previous element is text, append the current text to it
-							if (this._elements.length && this._elements[this._elements.length - 1].type == ElementType.Text) {
+							if (this._elements.length) {
 								var prevElement = this._elements[this._elements.length - 1];
-								prevElement.raw = prevElement.data = prevElement.raw + this._prevTagSep + element.raw;
-								element.raw = element.data = ""; //This causes the current element to not be added to the element list
+								if (prevElement.type === ElementType.Text) {
+									prevElement.raw = prevElement.data = prevElement.raw + this._prevTagSep + element.raw;
+									element.raw = element.data = ""; //This causes the current element to not be added to the element list
+								} else if (element.type === 'tag') {
+									element.raw = element.data = '<' + element.raw;
+								}
 							}
+							element.type = ElementType.Text;
 						}
 					}
 				}

--- a/tests/23-tag-as-the-first-thing-inside-script.js
+++ b/tests/23-tag-as-the-first-thing-inside-script.js
@@ -1,0 +1,56 @@
+(function () {
+
+function RunningInNode () {
+	return(
+		(typeof require) == "function"
+		&&
+		(typeof exports) == "object"
+		&&
+		(typeof module) == "object"
+		&&
+		(typeof __filename) == "string"
+		&&
+		(typeof __dirname) == "string"
+		);
+}
+
+if (!RunningInNode()) {
+	if (!this.Tautologistics)
+		this.Tautologistics = {};
+	if (!this.Tautologistics.NodeHtmlParser)
+		this.Tautologistics.NodeHtmlParser = {};
+	if (!this.Tautologistics.NodeHtmlParser.Tests)
+		this.Tautologistics.NodeHtmlParser.Tests = [];
+	exports = {};
+	this.Tautologistics.NodeHtmlParser.Tests.push(exports);
+}
+
+exports.name = "Tag as the first thing inside <script>";
+exports.options = {
+	  handler: {}
+	, parser: {}
+};
+exports.html = "<head><script type=\"text/html\"><div></div></script></head>";
+exports.expected =
+[ { raw: 'head'
+  , data: 'head'
+  , type: 'tag'
+  , name: 'head'
+  , children:
+     [ { raw: 'script type="text/html"'
+       , data: 'script type="text/html"'
+       , type: 'script'
+       , name: 'script'
+       , attribs: { type: 'text/html' }
+       , children:
+          [ { raw: '<div></div>'
+            , data: '<div></div>'
+            , type: 'text'
+            }
+          ]
+       }
+     ]
+  }
+];
+
+})();


### PR DESCRIPTION
Hi!

When a `<script>` contains something that looks like markup as the first token, the `<` is not included in `element.raw` and `element.data`. This causes problems when parsing templates that use the `type='text/html'` hack, for example:

```
<html>
<body>
    <script type='text/html'><div></div></script>
</body>
</html>
```

... which makes the `Text` element come out as `div></div>`.

The above is also included as a test case.

I ran into this issue with jsdom, which still uses htmlparser 1.x.
