### PR TITLE
Node stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ while (...) {
 parser.done();	
 ```
 
+##Streaming To Parser in Node
+
+```javascript
+fs.createReadStream('./path_to_file.html').pipe(parser);
+```
+
 ##Parsing RSS/Atom Feeds
 
 ```javascript

--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -63,6 +63,33 @@ function Parser (builder, options) {
     this.reset();
 }
 
+if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
+
+    var Stream = require('stream');
+    inherits(Parser, Stream);
+
+    Parser.prototype.writable = true;
+    Parser.prototype.write = function(data) {
+        if(data instanceof Buffer) {
+            data = data.toString();
+        }
+        this.parseChunk(data);
+    };
+
+    Parser.prototype.end = function(data) {
+        if (arguments.length) {
+            this.write(data);
+        }
+        this.writable = false;
+        this.done();
+    };
+
+    Parser.prototype.destroy = function() {
+        this.writable = false;
+    };
+
+}
+
     //**Public**//
     Parser.prototype.reset = function Parser$reset () {
         this._state = {

--- a/runtests.js
+++ b/runtests.js
@@ -204,6 +204,47 @@ testUtils.runParserTests(
             };
     });
 
+testUtils.runStreamingParserTests(
+      parserTests
+    , htmlparser.Parser
+    , null
+    , function (testName, testResult, actual, expected) {
+        console.log("[" + testName + "]: " + (testResult ? "passed" : "FAILED"));
+    }, function (elapsed, passed, failed) {
+        testResults['StreamingParser'] = {
+              elapsed: elapsed
+            , passed: passed
+            , failed: failed
+            };
+    });
+
+testUtils.runStreamingParserTests(
+      parserTests
+    , htmlparser.Parser
+    , function (test) {
+        var newTest = {};
+        for (var key in test) {
+            if (!test.hasOwnProperty(key)) {
+                continue;
+            }
+            newTest[key] = (key === 'data') ?
+                test.data.join('').split('')
+                :
+                test[key]
+                ;
+        }
+        return newTest;
+    }
+    , function (testName, testResult, actual, expected) {
+        console.log("[" + testName + "]: " + (testResult ? "passed" : "FAILED"));
+    }, function (elapsed, passed, failed) {
+        testResults['StreamingParser (streamed)'] = {
+              elapsed: elapsed
+            , passed: passed
+            , failed: failed
+            };
+    });
+
 console.log('');
 console.log('Test Results');
 console.log('------------------');


### PR DESCRIPTION
Adding support for standard Node writeable streams:

``` javascript
fs.createReadStream('./path_to_file.html').pipe(parser);
```
