### PR TITLE
Fixed bug #61 (Parser hangs on some input)

### DIFF
--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -71,7 +71,7 @@ function Parser (handler, options) {
 	Parser._reTrim = /(^\s+|\s+$)/g; //Trim leading/trailing whitespace
 	Parser._reTrimComment = /(^\!--|--$)/g; //Remove comment tag markup from comment contents
 	Parser._reWhitespace = /\s/g; //Used to find any whitespace to split on
-	Parser._reTagName = /^\s*(\/?)\s*([^\s\/]+)/; //Used to find the tag name for an element
+	Parser._reTagName = /^\s*(?:(\/)\s*)?([^\s\/]+)/; //Used to find the tag name for an element
 
 	//Regular expressions used for parsing (stateful)
 	Parser._reAttrib = //Find attributes in a tag

--- a/runtests.js
+++ b/runtests.js
@@ -24,7 +24,7 @@ var fs = require("fs");
 var htmlparser = require("./lib/htmlparser");
 
 var testFolder = "./tests";
-var chunkSize = 5;
+var defaultChunkSize = 5;
 
 var testFiles = fs.readdirSync(testFolder);
 var testCount = 0;
@@ -51,6 +51,7 @@ for (var i in testFiles) {
 	parser.parseComplete(test.html);
 	var resultComplete = handler.dom;
 	var chunkPos = 0;
+	var chunkSize = test.chunkSize || defaultChunkSize;
 	parser.reset();
 	while (chunkPos < test.html.length) {
 		parser.parseChunk(test.html.substring(chunkPos, chunkPos + chunkSize));

--- a/runtests.js
+++ b/runtests.js
@@ -30,9 +30,12 @@ var testFiles = fs.readdirSync(testFolder);
 var testCount = 0;
 var failedCount = 0;
 for (var i in testFiles) {
-	testCount++;
 	var fileParts = testFiles[i].split(".");
-	fileParts.pop();
+	var ext = fileParts.pop();
+	if ('js' != ext) {
+		continue;
+	}
+	testCount++;
 	var moduleName = fileParts.join(".");
 	var test = require(testFolder + "/" + moduleName);
 	var handlerCallback = function handlerCallback (error) {

--- a/tests/23-bug-61.js
+++ b/tests/23-bug-61.js
@@ -1,0 +1,42 @@
+(function () {
+
+function RunningInNode () {
+	return(
+		(typeof require) == "function"
+		&&
+		(typeof exports) == "object"
+		&&
+		(typeof module) == "object"
+		&&
+		(typeof __filename) == "string"
+		&&
+		(typeof __dirname) == "string"
+		);
+}
+
+if (!RunningInNode()) {
+	if (!this.Tautologistics)
+		this.Tautologistics = {};
+	if (!this.Tautologistics.NodeHtmlParser)
+		this.Tautologistics.NodeHtmlParser = {};
+	if (!this.Tautologistics.NodeHtmlParser.Tests)
+		this.Tautologistics.NodeHtmlParser.Tests = [];
+	exports = {};
+	this.Tautologistics.NodeHtmlParser.Tests.push(exports);
+}
+
+exports.name = "Bug 61";
+exports.options = {
+	  handler: {}
+	, parser: {}
+};
+exports.html = new Array(300000).join("\t") + "<";
+exports.chunkSize = 500;
+exports.expected =
+	[ { raw: exports.html.substr(0,exports.html.length-1)
+		  , data: exports.html.substr(0,exports.html.length-1)
+		  , type: 'text'
+	  }
+	];
+
+})();


### PR DESCRIPTION
This fixes bug #61 (Parser hangs on some input).

The bug is caused by `_reTagName` (`/^\s*(\/?)\s*([^\s\/]+)/`) doing too much backtracking when the input string contains many whitespaces.
