### PR TITLE
Add bower.json file to help include in other projects

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "node-htmlparser",
+  "version": "2.0.0",
+  "homepage": "http://github.com/tautologistics/node-htmlparser",
+  "authors": [
+    "Chris Winberry <chris@winberry.net>"
+  ],
+  "description": "Forgiving HTML/XML/RSS Parser in JS for *both* Node and Browsers",
+  "main": "lib/htmlparser.js",
+  "keywords": [
+    "html",
+    "xml"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
While the project is already listed in bower, this json file will help include just the `lib` directory.
