### PR TITLE
Add CommonJS/AMD support with UMD wrapper.

### DIFF
--- a/lib/htmlparser.js
+++ b/lib/htmlparser.js
@@ -20,21 +20,22 @@ IN THE SOFTWARE.
 ***********************************************/
 /* v2.0.0 */
 
-(function () {
+(function (root, factory) {
 
-var exports;
-if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
-    exports = module.exports;
+if (typeof(define) === 'function' && typeof(define.amd) !== 'undefined') {
+    define([], factory);
+} else if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
+    module.exports = factory();
 } else {
-    exports = {};
-    if (!this.Tautologistics) {
-        this.Tautologistics = {};
+    if (!root.Tautologistics) {
+        root.Tautologistics = {};
     }
-    if (this.Tautologistics.NodeHtmlParser) {
+    if (root.Tautologistics.NodeHtmlParser) {
         return;
     }
-    this.Tautologistics.NodeHtmlParser = exports;
+    root.Tautologistics.NodeHtmlParser = factory();
 }
+}(this, function (exports) {
 
 function inherits (ctor, superCtor) {
     var tempCtor = function(){};
@@ -64,7 +65,7 @@ function Parser (builder, options) {
     this.reset();
 }
 
-if (typeof(module) !== 'undefined' && typeof(module.exports) !== 'undefined') {
+if (typeof process === 'object' && Object.prototype.toString.call(process) === '[object process]') {
 
     var Stream = require('stream');
     inherits(Parser, Stream);
@@ -980,14 +981,11 @@ inherits(RssBuilder, HtmlBuilder);
         }
     };
 
-exports.Parser = Parser;
-
-exports.HtmlBuilder = HtmlBuilder;
-
-exports.RssBuilder = RssBuilder;
-
-exports.ElementType = Mode;
-
-exports.DomUtils = DomUtils;
-
-})();
+    return {
+        Parser: Parser,
+        HtmlBuilder: HtmlBuilder,
+        RssBuilder: RssBuilder,
+        ElementType: Mode,
+        DomUtils: DomUtils
+    };
+}));


### PR DESCRIPTION
In attempting to use this lib as a dependency, I was unable to use it in the browser as anything other than a global. This patch wraps htmlparser with a [UMD pattern](https://github.com/umdjs/umd), so that loading via AMD or CommonJS is supported.
