### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,5 @@
 	, "directories": { "lib": "./lib/" }
 	, "main": "./lib/htmlparser"
 	, "engines": { "node": ">=0.5.0" }
-	, "licenses": [{
-		  "type": "MIT"
-		, "url": "http://github.com/tautologistics/node-htmlparser/raw/master/LICENSE"
-	}]
+	, "license" : "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
